### PR TITLE
SLEMA-47 Added a logging library

### DIFF
--- a/lib/main/main.dart
+++ b/lib/main/main.dart
@@ -2,12 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:pg_slema/main/presentation/controller/main_screen_controller.dart';
 import 'package:pg_slema/main/presentation/widget/main_screen.dart';
+import 'package:pg_slema/utils/log/logger_printer.dart';
 import 'package:provider/provider.dart';
 import 'package:pg_slema/features/motivation/controller/motivation_screen_controller.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
+import 'package:loggy/loggy.dart';
 
 void main() {
+  Loggy.initLoggy(
+    logPrinter: const LoggerPrinter(),
+  );
+
   tz.initializeTimeZones();
   tz.setLocalLocation(tz.getLocation('Poland'));
   runApp(

--- a/lib/utils/log/logger_mixin.dart
+++ b/lib/utils/log/logger_mixin.dart
@@ -1,0 +1,9 @@
+import 'package:loggy/loggy.dart';
+
+mixin Logger implements LoggyType {
+  Loggy<Logger> get logger => loggy;
+
+  @override
+  Loggy<Logger> get loggy =>
+      Loggy<Logger>(runtimeType.toString());
+}

--- a/lib/utils/log/logger_mixin.dart
+++ b/lib/utils/log/logger_mixin.dart
@@ -4,6 +4,5 @@ mixin Logger implements LoggyType {
   Loggy<Logger> get logger => loggy;
 
   @override
-  Loggy<Logger> get loggy =>
-      Loggy<Logger>(runtimeType.toString());
+  Loggy<Logger> get loggy => Loggy<Logger>(runtimeType.toString());
 }

--- a/lib/utils/log/logger_printer.dart
+++ b/lib/utils/log/logger_printer.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/foundation.dart';
+import 'package:loggy/loggy.dart';
+
+class LoggerPrinter extends LoggyPrinter {
+  const LoggerPrinter();
+
+  static final Map<LogLevel, String> _levelStrings = <LogLevel, String> {
+    LogLevel.debug: 'DEBUG',
+    LogLevel.info: 'INFO ',
+    LogLevel.warning: 'WARN ',
+    LogLevel.error: 'ERROR',
+  };
+
+  @override
+  void onLog(LogRecord record) {
+    if (kDebugMode) {
+      final String time = record.time.toIso8601String().split('T')[1];
+      final String logLevel = _levelStrings[record.level]!;
+      print('$time $logLevel ${record.loggerName} ${record.message}');
+    }
+  }
+}

--- a/lib/utils/log/logger_printer.dart
+++ b/lib/utils/log/logger_printer.dart
@@ -4,7 +4,7 @@ import 'package:loggy/loggy.dart';
 class LoggerPrinter extends LoggyPrinter {
   const LoggerPrinter();
 
-  static final Map<LogLevel, String> _levelStrings = <LogLevel, String> {
+  static final Map<LogLevel, String> _levelStrings = <LogLevel, String>{
     LogLevel.debug: 'DEBUG',
     LogLevel.info: 'INFO ',
     LogLevel.warning: 'WARN ',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -131,6 +131,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_loggy:
+    dependency: "direct main"
+    description:
+      name: flutter_loggy
+      sha256: "21b515977deefe37817cce35b0e420c7cde930b9dcfdcbeb05730ed24ee74e3a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -157,6 +165,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  loggy:
+    dependency: "direct main"
+    description:
+      name: loggy
+      sha256: "981e03162bbd3a5a843026f75f73d26e4a0d8aa035ae060456ca7b30dfd1e339"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
   matcher:
     dependency: transitive
     description:
@@ -253,6 +269,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.1"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.27.7"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,8 @@ dependencies:
   shared_preferences: ^2.2.2
   flutter_local_notifications: ^16.1.0
   timezone: ^0.9.2
+  flutter_loggy: ^2.0.2
+  loggy: ^2.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Jak korzystać z loggera?
1. Zaimportować logger_mixin.dart
![image](https://github.com/pikol93/PG_SLEMA/assets/40030490/97b27403-7bd9-4190-8419-c63738b8465b)

2. Dołączyć mixin do klasy nad którą obecnie się pracuje
![image](https://github.com/pikol93/PG_SLEMA/assets/40030490/a44a94e2-a2b0-4603-bf69-dfbce3dd7bc1)

3. Wywołać logger
![image](https://github.com/pikol93/PG_SLEMA/assets/40030490/dbd47f1a-c426-45e2-8791-ae712e77b325)

Alternatywnie, można też wywołać globalne metody logujące, jednak nie jest to zalecane z powodu braku informacji na temat lokalizacji logowania.
![image](https://github.com/pikol93/PG_SLEMA/assets/40030490/2171e7b3-2e8d-45e9-b996-f35a34239e1b)

Przykładowy output:
![image](https://github.com/pikol93/PG_SLEMA/assets/40030490/3a4dd896-4b5c-40dc-b362-89e2e14aea40)
