### PR TITLE
SLEMA-91 UI menu głównego

### DIFF
--- a/SlemaForAndroid/lib/features/home/presentation/widget/home_app_bar.dart
+++ b/SlemaForAndroid/lib/features/home/presentation/widget/home_app_bar.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+class HomeAppBar extends StatelessWidget {
+  const HomeAppBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: MediaQuery.of(context).size.width,
+      child: AppBar(
+        backgroundColor: Colors.transparent,
+        iconTheme: Theme.of(context)
+            .appBarTheme
+            .iconTheme!
+            .copyWith(color: const Color(0xFF133150)),
+        titleTextStyle: Theme.of(context).appBarTheme.titleTextStyle!.copyWith(
+              color: const Color(0xFF133150),
+              height: 0.0,
+              fontSize: 56,
+            ),
+        title: const Text("Dzień dobry!"),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('TODO ustawienia')));
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/SlemaForAndroid/lib/features/home/presentation/widget/home_app_bar.dart
+++ b/SlemaForAndroid/lib/features/home/presentation/widget/home_app_bar.dart
@@ -8,19 +8,21 @@ class HomeAppBar extends StatelessWidget {
     return SizedBox(
       width: MediaQuery.of(context).size.width,
       child: AppBar(
+        automaticallyImplyLeading: false,
         backgroundColor: Colors.transparent,
-        iconTheme: Theme.of(context)
-            .appBarTheme
-            .iconTheme!
-            .copyWith(color: const Color(0xFF133150)),
+        iconTheme: Theme.of(context).appBarTheme.iconTheme!.copyWith(
+              color: const Color(0xFF133150),
+              size: 48.0,
+            ),
         titleTextStyle: Theme.of(context).appBarTheme.titleTextStyle!.copyWith(
               color: const Color(0xFF133150),
               height: 0.0,
-              fontSize: 56,
+              fontSize: 64,
             ),
         title: const Text("Dzień dobry!"),
         actions: [
           IconButton(
+            padding: const EdgeInsets.only(bottom: 12.0, right: 12.0),
             icon: const Icon(Icons.settings),
             onPressed: () {
               ScaffoldMessenger.of(context).showSnackBar(

--- a/SlemaForAndroid/lib/features/home/presentation/widget/home_screen.dart
+++ b/SlemaForAndroid/lib/features/home/presentation/widget/home_screen.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:pg_slema/features/home/presentation/widget/home_app_bar.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  HomeScreenState createState() => HomeScreenState();
+}
+
+class HomeScreenState extends State<HomeScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: const Color(0xFFE7ECEF), //TODO
+      child: const Column(
+        children: [
+          SizedBox(
+            height: 20.0,
+          ),
+          HomeAppBar(),
+        ],
+      ),
+    );
+  }
+}

--- a/SlemaForAndroid/lib/features/home/presentation/widget/home_screen.dart
+++ b/SlemaForAndroid/lib/features/home/presentation/widget/home_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:pg_slema/features/home/presentation/widget/home_app_bar.dart';
+import 'package:pg_slema/features/home/presentation/widget/home_widget_custom_container.dart';
 import 'package:pg_slema/features/home/presentation/widget/labeled_divider.dart';
+import 'package:pg_slema/features/motivation/presentation/widget/motivation_daily.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -21,17 +23,21 @@ class HomeScreenState extends State<HomeScreen> {
           ),
           HomeAppBar(),
           SizedBox(
-            height: 10.0,
+            height: 20.0,
           ),
           LabeledDivider(label: "Dzienny raport zdrowotny"),
           SizedBox(
-            height: 10.0,
+            height: 20.0,
           ),
           LabeledDivider(label: "Nadchodzące wydarzenia"),
           SizedBox(
-            height: 10.0,
+            height: 20.0,
           ),
           LabeledDivider(label: "Dla ciebie"),
+          SizedBox(
+            height: 20.0,
+          ),
+          HomeWidgetCustomContainer(child: MotivationDaily()),
         ],
       ),
     );

--- a/SlemaForAndroid/lib/features/home/presentation/widget/home_screen.dart
+++ b/SlemaForAndroid/lib/features/home/presentation/widget/home_screen.dart
@@ -47,7 +47,7 @@ class HomeScreenState extends State<HomeScreen> {
           ),
           HomeWidgetCustomContainer(
               child: Text(
-            "---------Raport zdrowotny---------",
+            "-------------Kalendarz------------",
             style: Theme.of(context).textTheme.labelMedium!.copyWith(
                   height: 1.0,
                   fontWeight: FontWeight.w600,

--- a/SlemaForAndroid/lib/features/home/presentation/widget/home_screen.dart
+++ b/SlemaForAndroid/lib/features/home/presentation/widget/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pg_slema/features/home/presentation/widget/home_app_bar.dart';
+import 'package:pg_slema/features/home/presentation/widget/labeled_divider.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -19,6 +20,18 @@ class HomeScreenState extends State<HomeScreen> {
             height: 20.0,
           ),
           HomeAppBar(),
+          SizedBox(
+            height: 10.0,
+          ),
+          LabeledDivider(label: "Dzienny raport zdrowotny"),
+          SizedBox(
+            height: 10.0,
+          ),
+          LabeledDivider(label: "Nadchodzące wydarzenia"),
+          SizedBox(
+            height: 10.0,
+          ),
+          LabeledDivider(label: "Dla ciebie"),
         ],
       ),
     );

--- a/SlemaForAndroid/lib/features/home/presentation/widget/home_screen.dart
+++ b/SlemaForAndroid/lib/features/home/presentation/widget/home_screen.dart
@@ -16,28 +16,52 @@ class HomeScreenState extends State<HomeScreen> {
   Widget build(BuildContext context) {
     return Container(
       color: const Color(0xFFE7ECEF), //TODO
-      child: const Column(
+      child: Column(
         children: [
-          SizedBox(
+          const SizedBox(
             height: 20.0,
           ),
-          HomeAppBar(),
-          SizedBox(
+          const HomeAppBar(),
+          const SizedBox(
             height: 20.0,
           ),
-          LabeledDivider(label: "Dzienny raport zdrowotny"),
-          SizedBox(
+          const LabeledDivider(label: "Dzienny raport zdrowotny"),
+          const SizedBox(
             height: 20.0,
           ),
-          LabeledDivider(label: "Nadchodzące wydarzenia"),
-          SizedBox(
+          HomeWidgetCustomContainer(
+              child: Text(
+            "---------Raport zdrowotny---------",
+            style: Theme.of(context).textTheme.labelMedium!.copyWith(
+                  height: 1.0,
+                  fontWeight: FontWeight.w600,
+                  color: const Color(0xFF133150), //TODO
+                ),
+          )),
+          const SizedBox(
             height: 20.0,
           ),
-          LabeledDivider(label: "Dla ciebie"),
-          SizedBox(
+          const LabeledDivider(label: "Nadchodzące wydarzenia"),
+          const SizedBox(
             height: 20.0,
           ),
-          HomeWidgetCustomContainer(child: MotivationDaily()),
+          HomeWidgetCustomContainer(
+              child: Text(
+            "---------Raport zdrowotny---------",
+            style: Theme.of(context).textTheme.labelMedium!.copyWith(
+                  height: 1.0,
+                  fontWeight: FontWeight.w600,
+                  color: const Color(0xFF133150), //TODO
+                ),
+          )),
+          const SizedBox(
+            height: 20.0,
+          ),
+          const LabeledDivider(label: "Dla ciebie"),
+          const SizedBox(
+            height: 20.0,
+          ),
+          const HomeWidgetCustomContainer(child: MotivationDaily()),
         ],
       ),
     );

--- a/SlemaForAndroid/lib/features/home/presentation/widget/home_widget_custom_container.dart
+++ b/SlemaForAndroid/lib/features/home/presentation/widget/home_widget_custom_container.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class HomeWidgetCustomContainer extends StatelessWidget {
+  final Widget child;
+  const HomeWidgetCustomContainer({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    final double screenWidthMargin = MediaQuery.of(context).size.width * 0.08;
+    return Container(
+      margin:
+          EdgeInsets.only(left: screenWidthMargin, right: screenWidthMargin),
+      child: Material(
+        elevation: 3.0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16.0),
+          side: const BorderSide(
+            color: Color(0xFF133150), //TODO
+            width: 3.0,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(14.0),
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/SlemaForAndroid/lib/features/home/presentation/widget/labeled_divider.dart
+++ b/SlemaForAndroid/lib/features/home/presentation/widget/labeled_divider.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:pg_slema/theme/custom_colors.dart';
+
+class LabeledDivider extends StatelessWidget {
+  final String label;
+  const LabeledDivider({super.key, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final MyColors? myColors = Theme.of(context).extension<MyColors>();
+
+    return Align(
+      alignment: Alignment.topLeft,
+      child: Material(
+        elevation: 4.0,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.only(
+            topRight: Radius.circular(16.0),
+            bottomRight: Radius.circular(16.0),
+          ),
+        ),
+        child: Container(
+          padding: const EdgeInsets.only(left: 20.0),
+          width: MediaQuery.of(context).size.width * 0.75,
+          decoration: BoxDecoration(
+            color: Theme.of(context).navigationBarTheme.backgroundColor,
+            borderRadius: const BorderRadius.only(
+              topRight: Radius.circular(16.0),
+              bottomRight: Radius.circular(16.0),
+            ),
+          ),
+          child: Text(
+            label,
+            style: Theme.of(context).textTheme.headlineSmall!.copyWith(
+                color: myColors?.formsButtonTextColor ?? Colors.white, //TODO
+                height: 1.0),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/SlemaForAndroid/lib/features/motivation/presentation/widget/motivation_daily.dart
+++ b/SlemaForAndroid/lib/features/motivation/presentation/widget/motivation_daily.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:pg_slema/features/motivation/controller/motivation_screen_controller.dart';
+import 'package:provider/provider.dart';
+
+class MotivationDaily extends StatefulWidget {
+  const MotivationDaily({super.key});
+
+  @override
+  State<MotivationDaily> createState() => _MotivationDailyState();
+}
+
+class _MotivationDailyState extends State<MotivationDaily> {
+  late MotivationScreenController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller =
+        Provider.of<MotivationScreenController>(context, listen: false);
+  }
+
+  @override
+  void didChangeDependencies() async {
+    super.didChangeDependencies();
+    if (_controller.currentQuote.isEmpty) {
+      await _controller.loadQuotes();
+      _reloadQuote();
+    }
+  }
+
+  void _reloadQuote() {
+    String newQuote = _controller.getNewQuote();
+    setState(() {
+      _controller.currentQuote = newQuote;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          "Twój codzienny cytat",
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.labelMedium!.copyWith(
+                height: 1.0,
+                fontWeight: FontWeight.w600,
+                color: const Color(0xFF133150), //TODO
+              ),
+        ),
+        Text(
+          _controller.currentQuote,
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.labelMedium!.copyWith(
+                height: 1.0,
+                fontWeight: FontWeight.w400,
+                fontStyle: FontStyle.italic,
+                wordSpacing: -3.0, //TODO
+                color: const Color(0xB2133150), //TODO
+              ),
+        ),
+      ],
+    );
+  }
+}

--- a/SlemaForAndroid/lib/main/presentation/controller/main_screen_controller.dart
+++ b/SlemaForAndroid/lib/main/presentation/controller/main_screen_controller.dart
@@ -13,10 +13,8 @@ class MainScreenController extends ChangeNotifier {
 
   void onTabTapped(int index) {
     currentIndex = index;
-    pageController.animateToPage(
+    pageController.jumpToPage(
       index,
-      duration: const Duration(milliseconds: 150),
-      curve: Curves.ease,
     );
   }
 }

--- a/SlemaForAndroid/lib/main/presentation/controller/main_screen_controller.dart
+++ b/SlemaForAndroid/lib/main/presentation/controller/main_screen_controller.dart
@@ -1,8 +1,4 @@
 import 'package:flutter/cupertino.dart';
-import 'package:pg_slema/features/diet/presentation/widget/diet_screen.dart';
-import 'package:pg_slema/features/exercises/presentation/widget/exercises_screen.dart';
-import 'package:pg_slema/features/medicine/presentation/widget/get_medicines_screen.dart';
-import 'package:pg_slema/features/motivation/presentation/widget/motivation_screen.dart';
 
 class MainScreenController extends ChangeNotifier {
   int _currentIndex = 0;
@@ -14,13 +10,6 @@ class MainScreenController extends ChangeNotifier {
   }
 
   final PageController pageController = PageController();
-
-  final List<Widget> views = [
-    const MotivationScreen(),
-    GetMedicinesScreen(),
-    const DietScreen(),
-    const ExercisesScreen(),
-  ];
 
   void onTabTapped(int index) {
     currentIndex = index;

--- a/SlemaForAndroid/lib/main/presentation/widget/custom_navigation_destination.dart
+++ b/SlemaForAndroid/lib/main/presentation/widget/custom_navigation_destination.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+class CustomNavigationDestination extends StatefulWidget {
+  final Icon icon;
+  final Icon selectedIcon;
+  final String label;
+  const CustomNavigationDestination(
+      {super.key,
+      required this.icon,
+      required this.selectedIcon,
+      required this.label});
+
+  @override
+  CustomNavigationDestinationState createState() =>
+      CustomNavigationDestinationState();
+}
+
+class CustomNavigationDestinationState
+    extends State<CustomNavigationDestination> {
+  @override
+  Widget build(BuildContext context) {
+    final iconThemeData = Theme.of(context)
+        .navigationBarTheme
+        .iconTheme!
+        .resolve(<MaterialState>{});
+
+    return NavigationDestination(
+      selectedIcon: Container(
+          margin: const EdgeInsets.only(top: 5.0, bottom: 5.0),
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: iconThemeData?.color ?? Colors.transparent,
+              width: 2.0,
+            ),
+            borderRadius: BorderRadius.circular(10.0),
+          ),
+          child: widget.selectedIcon),
+      icon: Container(
+          margin: const EdgeInsets.only(top: 5.0, bottom: 5.0),
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: iconThemeData?.color ?? Colors.transparent,
+              width: 2.0,
+            ),
+            borderRadius: BorderRadius.circular(10.0),
+          ),
+          child: widget.icon),
+      label: widget.label,
+    );
+  }
+}

--- a/SlemaForAndroid/lib/main/presentation/widget/main_screen.dart
+++ b/SlemaForAndroid/lib/main/presentation/widget/main_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pg_slema/main/presentation/controller/main_screen_controller.dart';
+import 'package:pg_slema/main/presentation/widget/custom_navigation_destination.dart';
 import 'package:provider/provider.dart';
 
 class MainScreen extends StatefulWidget {
@@ -25,26 +26,22 @@ class MainScreenState extends State<MainScreen> {
         selectedIndex: controller.currentIndex,
         onDestinationSelected: controller.onTabTapped,
         destinations: const <Widget>[
-          NavigationDestination(
-            selectedIcon: Icon(Icons.lightbulb),
-            icon: Icon(Icons.lightbulb_outlined),
-            label: 'Motywacja',
-          ),
-          NavigationDestination(
-            selectedIcon: Icon(Icons.medication),
-            icon: Icon(Icons.medication_outlined),
-            label: 'Leki',
-          ),
-          NavigationDestination(
-            selectedIcon: Icon(Icons.restaurant_menu_outlined),
-            icon: Icon(Icons.restaurant_menu),
-            label: 'Dieta',
-          ),
-          NavigationDestination(
-            selectedIcon: Icon(Icons.fitness_center_outlined),
-            icon: Icon(Icons.fitness_center),
-            label: 'Ćwiczenia',
-          ),
+          CustomNavigationDestination(
+              icon: Icon(Icons.home_outlined),
+              selectedIcon: Icon(Icons.home),
+              label: 'Start'),
+          CustomNavigationDestination(
+              icon: Icon(Icons.medication_outlined),
+              selectedIcon: Icon(Icons.medication),
+              label: 'Leki'),
+          CustomNavigationDestination(
+              icon: Icon(Icons.restaurant_menu_outlined),
+              selectedIcon: Icon(Icons.restaurant_menu),
+              label: 'Dieta'),
+          CustomNavigationDestination(
+              icon: Icon(Icons.fitness_center_outlined),
+              selectedIcon: Icon(Icons.fitness_center),
+              label: 'Ćwiczenia'),
         ],
       ),
     );

--- a/SlemaForAndroid/lib/main/presentation/widget/main_screen.dart
+++ b/SlemaForAndroid/lib/main/presentation/widget/main_screen.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:pg_slema/main/presentation/controller/main_screen_controller.dart';
 import 'package:pg_slema/main/presentation/widget/custom_navigation_destination.dart';
 import 'package:provider/provider.dart';
+import 'package:pg_slema/features/diet/presentation/widget/diet_screen.dart';
+import 'package:pg_slema/features/exercises/presentation/widget/exercises_screen.dart';
+import 'package:pg_slema/features/medicine/presentation/widget/get_medicines_screen.dart';
+import 'package:pg_slema/features/motivation/presentation/widget/motivation_screen.dart';
 
 class MainScreen extends StatefulWidget {
   const MainScreen({super.key});
@@ -19,7 +23,12 @@ class MainScreenState extends State<MainScreen> {
       body: PageView(
         controller: controller.pageController,
         physics: const NeverScrollableScrollPhysics(),
-        children: controller.views,
+        children: [
+          const MotivationScreen(),
+          GetMedicinesScreen(),
+          const DietScreen(),
+          const ExercisesScreen(),
+        ],
       ),
       bottomNavigationBar: NavigationBar(
         labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,

--- a/SlemaForAndroid/lib/main/presentation/widget/main_screen.dart
+++ b/SlemaForAndroid/lib/main/presentation/widget/main_screen.dart
@@ -24,7 +24,6 @@ class MainScreenState extends State<MainScreen> {
         labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
         selectedIndex: controller.currentIndex,
         onDestinationSelected: controller.onTabTapped,
-        height: 70,
         destinations: const <Widget>[
           NavigationDestination(
             selectedIcon: Icon(Icons.lightbulb),

--- a/SlemaForAndroid/lib/main/presentation/widget/main_screen.dart
+++ b/SlemaForAndroid/lib/main/presentation/widget/main_screen.dart
@@ -15,9 +15,6 @@ class MainScreenState extends State<MainScreen> {
     final controller = Provider.of<MainScreenController>(context);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Main screen app bar'),
-      ),
       body: PageView(
         controller: controller.pageController,
         physics: const NeverScrollableScrollPhysics(),

--- a/SlemaForAndroid/lib/main/presentation/widget/main_screen.dart
+++ b/SlemaForAndroid/lib/main/presentation/widget/main_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:pg_slema/features/home/presentation/widget/home_screen.dart';
 import 'package:pg_slema/main/presentation/controller/main_screen_controller.dart';
 import 'package:pg_slema/main/presentation/widget/custom_navigation_destination.dart';
 import 'package:provider/provider.dart';
@@ -24,7 +25,7 @@ class MainScreenState extends State<MainScreen> {
         controller: controller.pageController,
         physics: const NeverScrollableScrollPhysics(),
         children: [
-          const MotivationScreen(),
+          const HomeScreen(),
           GetMedicinesScreen(),
           const DietScreen(),
           const ExercisesScreen(),

--- a/SlemaForAndroid/lib/main/presentation/widget/main_screen.dart
+++ b/SlemaForAndroid/lib/main/presentation/widget/main_screen.dart
@@ -6,7 +6,6 @@ import 'package:provider/provider.dart';
 import 'package:pg_slema/features/diet/presentation/widget/diet_screen.dart';
 import 'package:pg_slema/features/exercises/presentation/widget/exercises_screen.dart';
 import 'package:pg_slema/features/medicine/presentation/widget/get_medicines_screen.dart';
-import 'package:pg_slema/features/motivation/presentation/widget/motivation_screen.dart';
 
 class MainScreen extends StatefulWidget {
   const MainScreen({super.key});

--- a/SlemaForAndroid/lib/theme/theme_constants.dart
+++ b/SlemaForAndroid/lib/theme/theme_constants.dart
@@ -35,6 +35,7 @@ ThemeData lightTheme = ThemeData(
       ),
       headlineSmall: TextStyle(
         fontSize: 32,
+        fontWeight: FontWeight.w700,
       ),
       labelMedium: TextStyle(
         fontSize: 28,

--- a/SlemaForAndroid/lib/theme/theme_constants.dart
+++ b/SlemaForAndroid/lib/theme/theme_constants.dart
@@ -47,11 +47,10 @@ ThemeData lightTheme = ThemeData(
       backgroundColor: colorNavigationBarBackground,
       indicatorColor: const Color(0X00000000),
       elevation: 0,
-      height: 96,
       shadowColor: colorNavigationBarShadow,
       labelTextStyle: MaterialStateProperty.resolveWith((states) {
         return const TextStyle(
-          height: 1.0,
+          height: 0.7,
           fontSize: 24.0,
           fontWeight: FontWeight.w700,
           color: colorNavigationBarText,

--- a/SlemaForAndroid/lib/theme/theme_constants.dart
+++ b/SlemaForAndroid/lib/theme/theme_constants.dart
@@ -7,6 +7,9 @@ const colorSchemeSeed = Color(0xFF1E81B0);
 //NavigationBar
 const colorNavigationBarBackground = Color(0xFF6793B3);
 const colorNavigationBarShadow = Color(0x1A000000);
+const colorNavigationBarIcon = Color(0xCCF2F1EB);
+const colorNavigationBarIconSelected = Color(0xCCF2F1EB);
+const colorNavigationBarText = Color(0xCCF2F1EB);
 
 //AppBar
 const colorAppBarText = Color(0xFFF2F1EB);
@@ -40,11 +43,32 @@ ThemeData lightTheme = ThemeData(
     useMaterial3: true,
     brightness: Brightness.light,
     colorSchemeSeed: colorSchemeSeed,
-    navigationBarTheme: const NavigationBarThemeData(
+    navigationBarTheme: NavigationBarThemeData(
       backgroundColor: colorNavigationBarBackground,
+      indicatorColor: const Color(0X00000000),
       elevation: 0,
-      height: 72,
+      height: 96,
       shadowColor: colorNavigationBarShadow,
+      labelTextStyle: MaterialStateProperty.resolveWith((states) {
+        return const TextStyle(
+          height: 1.0,
+          fontSize: 24.0,
+          fontWeight: FontWeight.w700,
+          color: colorNavigationBarText,
+        );
+      }),
+      iconTheme: MaterialStateProperty.resolveWith((states) {
+        if (states.contains(MaterialState.selected)) {
+          return const IconThemeData(
+            size: 36.0,
+            color: colorNavigationBarIconSelected,
+          );
+        }
+        return const IconThemeData(
+          size: 36.0,
+          color: colorNavigationBarIcon,
+        );
+      }),
     ),
     appBarTheme: const AppBarTheme(
       titleTextStyle: TextStyle(

--- a/SlemaForAndroid/lib/theme/theme_constants.dart
+++ b/SlemaForAndroid/lib/theme/theme_constants.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:pg_slema/theme/custom_colors.dart';
 
-const colorSchemeSeed = Color(0xFF1E81B0);
+const colorSchemeSeed = Color(0xFF6793B3);
 
 //NavigationBar
 const colorNavigationBarBackground = Color(0xFF6793B3);
@@ -20,6 +20,9 @@ const colorAppBarBackground = Color(0xFF6793B3);
 const colorCustomSaveButtonBackground = Color(0xFF487ABC);
 const colorCustomSaveButtonText = Color(0xFFF2F1EB);
 const colorCustomInputTextBorder = Color(0xB2878787);
+
+//Background
+const colorScaffoldBackgroundColor = Color(0xFFE7ECEF);
 
 ThemeData lightTheme = ThemeData(
     fontFamily: 'Dongle',


### PR DESCRIPTION
![image](https://github.com/pikol93/PG_SLEMA/assets/67384782/1741947e-5783-4e89-a451-8f546d2df66f)

Stan na teraz. Nie chcę reszty robić, bo nie ma to sensu bez logiki.
Menu zamiast motywacji.
Przeniesione widoki z kontrolera main screena.
Wyłączona animacja przechodzenia przez wszystkie karty do wybranej.
Dużo problemów z kolorami i stylami (poruszę na spotkaniu), oznaczyłem wszystko jako TODO i zajmę się tym w następnych taskach. Moglibysmy teoretycznie nie mergować tego i nie wprowadzać tego syfu, ale moze czemu nie? Działa
