### PR TITLE
SLEMA-175 Implemented UI for all assessments

### DIFF
--- a/SlemaForAndroid/lib/features/well_being/logic/entity/enum/sleep_duration.dart
+++ b/SlemaForAndroid/lib/features/well_being/logic/entity/enum/sleep_duration.dart
@@ -30,4 +30,8 @@ extension SleepDurationExtension on SleepDuration {
         throw ArgumentError("Unexpected argument \"$this\"");
     }
   }
+
+  String get hourTextRepresentation {
+    return "${buttonTextRepresentation}h";
+  }
 }

--- a/SlemaForAndroid/lib/features/well_being/presentation/screen/all_assessments_screen.dart
+++ b/SlemaForAndroid/lib/features/well_being/presentation/screen/all_assessments_screen.dart
@@ -6,7 +6,7 @@ import 'package:pg_slema/features/well_being/logic/entity/assessment_factory.dar
 import 'package:pg_slema/features/well_being/logic/service/assessments_service.dart';
 import 'package:pg_slema/features/well_being/presentation/widget/all_assessments/single_assessment_widget.dart';
 import 'package:pg_slema/utils/log/logger_mixin.dart';
-import 'package:pg_slema/utils/widgets/appbars/default_appbar.dart';
+import 'package:pg_slema/utils/widgets/appbars/white_app_bar.dart';
 import 'package:pg_slema/utils/widgets/default_body/default_body.dart';
 
 class AllAssessmentsScreen extends StatefulWidget {
@@ -50,7 +50,8 @@ class _AllAssessmentsScreenState extends State<AllAssessmentsScreen>
   Widget build(BuildContext context) {
     return Column(
       children: [
-        const DefaultAppBar(title: "Raporty zdrowotne"),
+        const SizedBox(height: 20.0),
+        const WhiteAppBar(titleText: "Raporty"),
         DefaultBody(
           child: FutureBuilder(
             future: assessmentsFuture,

--- a/SlemaForAndroid/lib/features/well_being/presentation/widget/all_assessments/single_assessment_widget.dart
+++ b/SlemaForAndroid/lib/features/well_being/presentation/widget/all_assessments/single_assessment_widget.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:pg_slema/features/well_being/logic/entity/assessment.dart';
+import 'package:pg_slema/features/well_being/logic/entity/enum/sleep_duration.dart';
+import 'package:pg_slema/features/well_being/logic/entity/enum/sleep_quality.dart';
+import 'package:pg_slema/features/well_being/logic/entity/enum/symptom_value.dart';
 import 'package:pg_slema/features/well_being/logic/entity/enum/well_being_variant.dart';
 import 'package:pg_slema/features/well_being/presentation/screen/assessment_screen.dart';
+import 'package:pg_slema/utils/date/date.dart';
 import 'package:pg_slema/utils/log/logger_mixin.dart';
 import 'package:pg_slema/utils/widgets/default_container/default_container.dart';
 
@@ -19,50 +23,184 @@ class SingleAssessmentWidget extends StatefulWidget {
 
 class SingleAssessmentWidgetState extends State<SingleAssessmentWidget>
     with Logger {
+  static const double sectionTextHeightOverride = 1;
+  static const double dataTextHeightOverride = 0.75;
+
   BuildContext? buildContext;
 
   @override
   Widget build(BuildContext context) {
     buildContext = context;
 
+    TextStyle keyStyle = Theme.of(context).textTheme.labelLarge!.copyWith(
+          height: sectionTextHeightOverride,
+          fontWeight: FontWeight.w800,
+        );
+
     return DefaultContainer(
       padding: const EdgeInsets.symmetric(vertical: 10.0),
-      child: Stack(
+      child: Column(
         children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
+          _buildDateRow(keyStyle),
+          const Divider(height: 8.0, thickness: 2.0),
+          _buildSymptomsRow(keyStyle),
+          const Divider(height: 8.0, thickness: 2.0),
+          _buildSleepRow(keyStyle),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDateRow(
+    TextStyle sectionTextStyle,
+  ) {
+    final TextStyle dateTextStyle =
+        Theme.of(context).textTheme.labelLarge!.copyWith(
+              height: dataTextHeightOverride,
+              fontWeight: FontWeight.w500,
+            );
+
+    return Row(
+      children: [
+        Expanded(
+          child: Row(
             children: [
-              SizedBox(
-                height: 32.0,
-                child: widget.assessment.wellBeing.icon,
+              Text(
+                "Data:",
+                style: sectionTextStyle,
               ),
-              IconButton(
-                icon: Icon(
-                  Icons.edit,
-                  color: Theme.of(context).primaryColor,
-                ),
-                onPressed: _onEditPressed,
+              const SizedBox(width: 8.0),
+              Text(
+                widget.assessment.intakeDate.toDateString(),
+                style: dateTextStyle,
               ),
             ],
           ),
-          Column(
+        ),
+        Row(
+          children: [
+            SizedBox(
+              height: 32.0,
+              child: widget.assessment.wellBeing.icon,
+            ),
+            IconButton(
+              icon: Icon(
+                Icons.edit,
+                color: Theme.of(context).primaryColor,
+              ),
+              onPressed: _onEditPressed,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSymptomsRow(
+    TextStyle sectionTextStyle,
+  ) {
+    final TextStyle symptomNameTextStyle =
+        Theme.of(context).textTheme.labelMedium!.copyWith(
+              height: dataTextHeightOverride,
+              fontWeight: FontWeight.w500,
+            );
+    final TextStyle symptomValueTextStyle =
+        Theme.of(context).textTheme.labelMedium!.copyWith(
+              height: dataTextHeightOverride,
+              fontWeight: FontWeight.w300,
+            );
+
+    final symptoms = widget.assessment.symptomEntries.symptomEntries
+        .map(
+          (e) => Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  e.name,
+                  style: symptomNameTextStyle,
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                  child: Text(
+                    e.value.textRepresentation,
+                    style: symptomValueTextStyle,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        )
+        .toList(growable: false);
+
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const SizedBox(height: 8.0),
-              Text("ID: ${widget.assessment.id}"),
-              const SizedBox(height: 8.0),
-              Text("Data: ${widget.assessment.intakeDate}"),
-              const SizedBox(height: 8.0),
-              Text("Samopoczucie: ${widget.assessment.wellBeing}"),
-              const SizedBox(height: 8.0),
-              Text("Symptomy: ${widget.assessment.symptomEntries}"),
-              const SizedBox(height: 8.0),
-              Text("Długość snu: ${widget.assessment.sleepDuration}"),
-              const SizedBox(height: 8.0),
-              Text("Jakość snu: ${widget.assessment.sleepQuality}"),
+              Text(
+                "Symptomy",
+                style: sectionTextStyle,
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(8.0, 0.0, 0.0, 0.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: symptoms,
+                ),
+              )
             ],
           ),
-        ],
+        )
+      ],
+    );
+  }
+
+  Widget _buildSleepRow(
+    TextStyle sectionTextStyle,
+  ) {
+    return Row(
+      children: [
+        Text(
+          "Sen",
+          style: sectionTextStyle,
+        ),
+        const SizedBox(width: 16.0),
+        Row(
+          children: [
+            _buildSleepContainer(
+              widget.assessment.sleepDuration.buttonTextRepresentation,
+            ),
+            const SizedBox(width: 8.0),
+            _buildSleepContainer(
+              widget.assessment.sleepQuality.buttonSubtitleTextRepresentation,
+            ),
+          ],
+        )
+      ],
+    );
+  }
+
+  Widget _buildSleepContainer(
+    String text,
+  ) {
+    final TextStyle symptomValueTextStyle =
+        Theme.of(context).textTheme.labelSmall!.copyWith(
+              height: dataTextHeightOverride,
+              fontWeight: FontWeight.w600,
+              color: Theme.of(context).colorScheme.primaryContainer,
+            );
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.primary,
+        borderRadius: const BorderRadius.all(Radius.circular(4.0)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 2.0),
+        child: Text(text, style: symptomValueTextStyle),
       ),
     );
   }

--- a/SlemaForAndroid/lib/features/well_being/presentation/widget/all_assessments/single_assessment_widget.dart
+++ b/SlemaForAndroid/lib/features/well_being/presentation/widget/all_assessments/single_assessment_widget.dart
@@ -171,7 +171,7 @@ class SingleAssessmentWidgetState extends State<SingleAssessmentWidget>
         Row(
           children: [
             _buildSleepContainer(
-              widget.assessment.sleepDuration.buttonTextRepresentation,
+              widget.assessment.sleepDuration.hourTextRepresentation,
             ),
             const SizedBox(width: 8.0),
             _buildSleepContainer(
@@ -196,7 +196,7 @@ class SingleAssessmentWidgetState extends State<SingleAssessmentWidget>
     return Container(
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.primary,
-        borderRadius: const BorderRadius.all(Radius.circular(4.0)),
+        borderRadius: const BorderRadius.all(Radius.circular(6.0)),
       ),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 2.0),

--- a/SlemaForAndroid/lib/features/well_being/presentation/widget/all_assessments/single_assessment_widget.dart
+++ b/SlemaForAndroid/lib/features/well_being/presentation/widget/all_assessments/single_assessment_widget.dart
@@ -41,7 +41,7 @@ class SingleAssessmentWidgetState extends State<SingleAssessmentWidget>
                   Icons.edit,
                   color: Theme.of(context).primaryColor,
                 ),
-                onPressed: onEditPressed,
+                onPressed: _onEditPressed,
               ),
             ],
           ),
@@ -67,7 +67,7 @@ class SingleAssessmentWidgetState extends State<SingleAssessmentWidget>
     );
   }
 
-  void onEditPressed() {
+  void _onEditPressed() {
     logger.debug("Edit pressed for assessment: ${widget.assessment.id}");
     Navigator.push(
       buildContext!,

--- a/SlemaForAndroid/lib/features/well_being/presentation/widget/all_assessments/single_assessment_widget.dart
+++ b/SlemaForAndroid/lib/features/well_being/presentation/widget/all_assessments/single_assessment_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pg_slema/features/well_being/logic/entity/assessment.dart';
+import 'package:pg_slema/features/well_being/logic/entity/enum/well_being_variant.dart';
 import 'package:pg_slema/features/well_being/presentation/screen/assessment_screen.dart';
 import 'package:pg_slema/utils/log/logger_mixin.dart';
 import 'package:pg_slema/utils/widgets/default_container/default_container.dart';
@@ -31,6 +32,10 @@ class SingleAssessmentWidgetState extends State<SingleAssessmentWidget>
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
+              SizedBox(
+                height: 32.0,
+                child: widget.assessment.wellBeing.icon,
+              ),
               IconButton(
                 icon: Icon(
                   Icons.edit,


### PR DESCRIPTION
![image](https://github.com/pikol93/PG_SLEMA/assets/40030490/d578936f-fdd2-4e8d-bac6-58b667036580)
![image](https://github.com/pikol93/PG_SLEMA/assets/40030490/6f62895e-8d6d-45de-96f8-bb3c0e443b5a)

Odstępstwa od projektu UI:
1. Dodanie przycisku w prawym górnym rogu raportu pozwalającego na edycję. Zmiana została uzgodniona z @AlicjaLukaszewicz, a przycisk będzie w przyszłości zmieniony na rozwijaną listę pozwalającą na usunięcie raportu.
2. Różnice w ikonach wynikające z różnic między obrazami w repo i tymi dostępnymi w aplikacji do projektowania.
3. Zmiany w sekcji symptomów spowodowane potrzebą uwzględnienia długich nazw symptomów, które mogą się nie zmieścić.

Powyżej wymienione odstępstwa uznaję za mało istotne. Zapraszam do dyskusji osoby, które chciałyby omówić wymienione odstępstwa.