### PR TITLE
SLEMA-197 Niepoprawny wygląd listy wątków czatu przy dostępnej opcji scrollowania

### DIFF
--- a/SlemaForAndroid/lib/features/exercises/presentation/screen/exercises_screen.dart
+++ b/SlemaForAndroid/lib/features/exercises/presentation/screen/exercises_screen.dart
@@ -34,7 +34,6 @@ class ExercisesScreenState extends State<ExercisesScreen> {
   @override
   Widget build(BuildContext context) {
     return Column(children: [
-      const SizedBox(height: 20.0),
       const WhiteAppBar(titleText: "Ćwiczenia"),
       DefaultBodyWithFloatingActionButton(
         onFloatingButtonPressed: _openAddExerciseScreen,

--- a/SlemaForAndroid/lib/utils/widgets/appbars/white_app_bar.dart
+++ b/SlemaForAndroid/lib/utils/widgets/appbars/white_app_bar.dart
@@ -15,6 +15,8 @@ class WhiteAppBar extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 20.0),
         child: AppBar(
+          scrolledUnderElevation:
+              0.0, //Disable scrolling under color change effect
           automaticallyImplyLeading: false,
           backgroundColor: Colors.transparent,
           iconTheme: Theme.of(context).appBarTheme.iconTheme!.copyWith(


### PR DESCRIPTION
Naprawiony white_app_bar. 
W sumie ten efekt jest przydatny, wiadomo co się dzieje na ekranie, ale nie pasuje do naszego projektu.